### PR TITLE
Update generate particle interface to no longer be part of

### DIFF
--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -76,7 +76,7 @@ boundary_p( particle_bc_t       * RESTRICT pbc_list,
 
   int n_send[6], n_recv[6], n_ci;
 
-  species_t * sp;
+  species_t* sp;
 
   int face;
 

--- a/src/emitter/child_langmuir.cc
+++ b/src/emitter/child_langmuir.cc
@@ -100,7 +100,7 @@ emit_child_langmuir( child_langmuir_t * RESTRICT              cl,
         p[np].u##Y = u##Y;                                              \
         p[np].u##Z = u##Z;                                              \
         p[np].w    = w;                                                 \
-        p_id[np] = sp->vsim->gen_particle_id(np, sp->max_np);           \
+        p_id[np] = sp->generate_particle_id(np, sp->max_np);            \
         accumulate_rhob( f, p+np, g, -qsp );                            \
         np++;                                                           \
                                                                         \

--- a/src/species_advance/species_advance.cc
+++ b/src/species_advance/species_advance.cc
@@ -32,7 +32,6 @@ checkpt_species( const species_t * sp )
   CHECKPT_ALIGNED( sp->partition, sp->g->nv+1, 128 );
   CHECKPT_PTR( sp->g );
   CHECKPT_PTR( sp->next );
-  CHECKPT_PTR( sp->vsim );
 }
 
 species_t *
@@ -47,7 +46,6 @@ restore_species( void )
   RESTORE_ALIGNED( sp->partition );
   RESTORE_PTR( sp->g );
   RESTORE_PTR( sp->next );
-  RESTORE_PTR( sp->vsim );
   return sp;
 }
 
@@ -125,8 +123,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g,
-         class vpic_simulation *vsim )
+         grid_t * g
+         )
 {
   species_t * sp;
   int len = name ? strlen(name) : 0;
@@ -159,7 +157,6 @@ species( const char * name,
   MALLOC_ALIGNED( sp->partition, g->nv+1, 128 );
 
   sp->g = g;
-  sp->vsim = vsim;
 
   /* id, next are set by append species */
 

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -54,8 +54,8 @@ species( const char * name,
          size_t max_local_nm,
          int sort_interval,
          int sort_out_of_place,
-         grid_t * g,
-         class vpic_simulation *vsim );
+         grid_t * g
+       );
 
 // FIXME: TEMPORARY HACK UNTIL THIS SPECIES_ADVANCE KERNELS
 // CAN BE CONSTRUCTED ANALOGOUS TO THE FIELD_ADVANCE KERNELS

--- a/src/species_advance/species_advance_aos.h
+++ b/src/species_advance/species_advance_aos.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Written by:
  *   Kevin J. Bowers, Ph.D.
  *   Plasma Physics Group (X-1)
@@ -11,6 +11,8 @@
 
 #ifndef _species_advance_aos_h_
 #define _species_advance_aos_h_
+
+#include <cassert>
 
 typedef int32_t species_id; // Must be 32-bit wide for particle_injector_t
 
@@ -52,48 +54,83 @@ typedef struct particle_injector {
   size_t global_particle_id;
 } particle_injector_t;
 
-typedef struct species {
-  char * name;                        // Species name
-  float q;                            // Species particle charge
-  float m;                            // Species particle rest mass
+class species_t {
+    public:
+        char * name;                        // Species name
+        float q;                            // Species particle charge
+        float m;                            // Species particle rest mass
 
-  int np, max_np;                     // Number and max local particles
-  particle_t * ALIGNED(128) p;        // Array of particles for the species
-  size_t* ALIGNED(128) p_id;          // Array of particles for the species
+        int np, max_np;                     // Number and max local particles
+        particle_t * ALIGNED(128) p;        // Array of particles for the species
+        size_t* ALIGNED(128) p_id;          // Array of particles for the species
 
-  int nm, max_nm;                     // Number and max local movers in use
-  particle_mover_t * ALIGNED(128) pm; // Particle movers
+        int nm, max_nm;                     // Number and max local movers in use
+        particle_mover_t * ALIGNED(128) pm; // Particle movers
 
-  int64_t last_sorted;                // Step when the particles were last
-                                      // sorted.
-  int sort_interval;                  // How often to sort the species
-  int sort_out_of_place;              // Sort method
-  int * ALIGNED(128) partition;       // Static array indexed 0:
-  /**/                                // (nx+2)*(ny+2)*(nz+2).  Each value
-  /**/                                // corresponds to the associated particle
-  /**/                                // array index of the first particle in
-  /**/                                // the cell.  Array is allocated and
-  /**/                                // values computed in sort_p.  Purpose is
-  /**/                                // for implementing collision models
-  /**/                                // This is given in terms of the
-  /**/                                // underlying's grids space filling
-  /**/                                // curve indexing.  Thus, immediately
-  /**/                                // after a sort:
-  /**/                                //   sp->p[sp->partition[g->sfc[i]  ]:
-  /**/                                //         sp->partition[g->sfc[i]+1]-1]
-  /**/                                // are all the particles in voxel
-  /**/                                // with local index i, while:
-  /**/                                //   sp->p[ sp->partition[ j   ]:
-  /**/                                //          sp->partition[ j+1 ] ]
-  /**/                                // are all the particles in voxel
-  /**/                                // with space filling curve index j.
-  /**/                                // Note: SFC NOT IN USE RIGHT NOW THUS
-  /**/                                // g->sfc[i]=i ABOVE.
+        int64_t last_sorted;                // Step when the particles were last
+        // sorted.
+        int sort_interval;                  // How often to sort the species
+        int sort_out_of_place;              // Sort method
+        int * ALIGNED(128) partition;       // Static array indexed 0:
+        /**/                                // (nx+2)*(ny+2)*(nz+2).  Each value
+        /**/                                // corresponds to the associated particle
+        /**/                                // array index of the first particle in
+        /**/                                // the cell.  Array is allocated and
+        /**/                                // values computed in sort_p.  Purpose is
+        /**/                                // for implementing collision models
+        /**/                                // This is given in terms of the
+        /**/                                // underlying's grids space filling
+        /**/                                // curve indexing.  Thus, immediately
+        /**/                                // after a sort:
+        /**/                                //   sp->p[sp->partition[g->sfc[i]  ]:
+        /**/                                //         sp->partition[g->sfc[i]+1]-1]
+        /**/                                // are all the particles in voxel
+        /**/                                // with local index i, while:
+        /**/                                //   sp->p[ sp->partition[ j   ]:
+        /**/                                //          sp->partition[ j+1 ] ]
+        /**/                                // are all the particles in voxel
+        /**/                                // with space filling curve index j.
+        /**/                                // Note: SFC NOT IN USE RIGHT NOW THUS
+        /**/                                // g->sfc[i]=i ABOVE.
 
-  grid_t * g;                         // Underlying grid
-  species_id id;                      // Unique identifier for a species
-  struct species *next;               // Next species in the list
-  class vpic_simulation *vsim;        // Simulation we belong to
-} species_t;
+        grid_t * g;                         // Underlying grid
+        species_id id;                      // Unique identifier for a species
+        species_t* next;                    // Next species in the list
+        class vpic_simulation *vsim;        // Simulation we belong to
+
+        // TODO: this is not technically guaranteed to be unique, but it's good for
+        // <how ever many times max_np fits inside the next highest order of
+        // magnitude> of the initial particle population
+        // TODO: this is probably better in binary, but it's nice for it to be human
+        // readable (for now), as it's essentially for diagnostics
+        /**
+         * @brief Determine a particle ID that has a high probably of being globally
+         * unique
+         *
+         * @param i Current local particle id (i.e slot in the particle array)
+         * @param max_np Max number of particles
+         * @param this_rank Rank to calculate it for (likely origin rank)
+         * @param scale_factor How much to space out the id_base, as a twiddle factor
+         * to avoid overlapping ids (10 is good if you won't overflow..)
+         *
+         * @return The global particle id
+         */
+        size_t generate_particle_id( int i, int max_np, int scale_factor = 1,
+                int this_rank = rank() )
+        {
+            // For now lets use a scheme for the append processor id to local id,
+            // such that if max_np = 128 and we want to generate a local id for
+            // particle 57 we produce:
+            // 1000 + 57 on rank 1 and 2000 + 57 on rank two
+
+            assert(scale_factor > 0);
+
+            // Find max bound by rounding to nearest order of magnitude
+            size_t id_base = ceil( log10(max_np) );
+            size_t global_id = (pow(10,  id_base) * (this_rank*scale_factor) ) + i;
+
+            return global_id;
+        }
+};
 
 #endif // _species_advance_aos_h_

--- a/src/util/util_base.h
+++ b/src/util/util_base.h
@@ -294,6 +294,10 @@ extern int _world_size;
 #define world_rank ((int)_world_rank)
 extern int _world_rank;
 
+inline int
+rank() { return world_rank; }
+
+
 // Strip all instances of key from the command line. Returns the
 // number of times key was found.
 

--- a/src/util/util_base.h
+++ b/src/util/util_base.h
@@ -297,6 +297,8 @@ extern int _world_rank;
 inline int
 rank() { return world_rank; }
 
+inline int
+nproc() { return world_size; }
 
 // Strip all instances of key from the command line. Returns the
 // number of times key was found.

--- a/src/vpic/misc.cc
+++ b/src/vpic/misc.cc
@@ -5,43 +5,7 @@
 //   Los Alamos National Lab
 // March/April 2004 - Original version
 
-#include <cassert>
 #include "vpic.h"
-
-// TODO: this is not technically guaranteed to be unique, but it's good for
-// <how ever many times max_np fits inside the next highest order of
-// magnitude> of the initial particle population
-// TODO: this is probably better in binary, but it's nice for it to be human
-// readable (for now), as it's essentially for diagnostics
-/**
- * @brief Determine a particle ID that has a high probably of being globally
- * unique
- *
- * @param i Current local particle id (i.e slot in the particle array)
- * @param max_np Max number of particles
- * @param this_rank Rank to calculate it for (likely origin rank)
- * @param scale_factor How much to space out the id_base, as a twiddle factor
- * to avoid overlapping ids (10 is good if you won't overflow..)
- *
- * @return The global particle id
- */
-size_t
-vpic_simulation::set_particle_id(int i, int max_np, int this_rank,
-                                 int scale_factor)
-{
-    // For now lets use a scheme for the append processor id to local id,
-    // such that if max_np = 128 and we want to generate a local id for
-    // particle 57 we produce:
-    // 1000 + 57 on rank 1 and 2000 + 57 on rank two
-
-    assert(scale_factor > 0);
-
-    // Find max bound by rounding to nearest order of magnitude
-    size_t id_base = ceil( log10(max_np) );
-    size_t global_id = (pow(10,  id_base) * (this_rank*scale_factor) ) + i;
-
-    return global_id;
-}
 
 // FIXME: MOVE THIS INTO VPIC.HXX TO BE TRULY INLINE
 void
@@ -118,7 +82,7 @@ vpic_simulation::inject_particle( species_t * sp,
   p->w  = w;
 
   // Set particle ID.
-  sp->p_id[old_np] = set_particle_id( old_np, sp->max_np, rank() );
+  sp->p_id[old_np] = sp->generate_particle_id( old_np, sp->max_np );
 
   if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
 

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -379,12 +379,6 @@ protected:
   ///////////////////
   // Useful accessors
 
-  inline int
-  rank() { return world_rank; }
-
-  inline int
-  nproc() { return world_size; }
-
   inline void
   barrier() { mp_barrier(); }
 

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -149,11 +149,6 @@ public:
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (int)> f);
   void predicate_copy(species_t* sp_from, species_t* sp_to, std::function <bool (particle_t)> f);
 
-  /* XXX: public interface to set_particle_id() for child_langmuir.cc */
-  int gen_particle_id(int np, int maxnp) {
-       return set_particle_id(np, maxnp, rank());
-  }
-
 protected:
 
   // Directly initialized by user
@@ -629,7 +624,7 @@ protected:
     return append_species( species( name, (float)q, (float)m,
                                     (size_t)max_local_np, (size_t)max_local_nm,
                                     (int)sort_interval, (int)sort_out_of_place,
-                                    grid, this ), &species_list );
+                                    grid ), &species_list );
   }
 
   inline species_t *
@@ -642,14 +637,7 @@ protected:
      return find_species_id( id, species_list );
   }
 
-  ///////////////////
-  // Particle helpers
-
-  size_t set_particle_id( int i, int max_np, int this_rank,
-                          int scale_factor = 1);
-
   // Note: Don't use injection with aging during initialization
-
   // Defaults in the declaration below enable backwards compatibility.
 
   void
@@ -676,7 +664,7 @@ protected:
     size_t * RESTRICT p_id = sp->p_id + sp->np;
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = set_particle_id(sp->np, sp->max_np, rank());
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     sp->np++;
   }
 
@@ -694,7 +682,7 @@ protected:
     particle_mover_t * RESTRICT pm = sp->pm + sp->nm;
     p->dx = dx; p->dy = dy; p->dz = dz; p->i = i;
     p->ux = ux; p->uy = uy; p->uz = uz; p->w = w;
-    *p_id = set_particle_id(sp->np, sp->max_np, rank());
+    *p_id = sp->generate_particle_id( sp->np, sp->max_np );
     pm->dispx = dispx; pm->dispy = dispy; pm->dispz = dispz; pm->i = sp->np-1;
     if( update_rhob ) accumulate_rhob( field_array->f, p, grid, -sp->q );
     sp->nm += move_p( sp->p, pm, accumulator_array->a, grid, sp->q );


### PR DESCRIPTION
vpic_simulation class

- Change `set_particle_id` interface to `generate_particle_id`
- Move `generate_particle_id` into `species_t` from `vpic_simulation_t`
- Make `rank()` accessible from more locations
- Remove chucks `species_t` back pointer to `vpic_simumlation_t` as it's no longer required